### PR TITLE
Add the `FastAsyncLock`

### DIFF
--- a/src/Uno.Core.Tests/Threading/AsyncLockFixture.cs
+++ b/src/Uno.Core.Tests/Threading/AsyncLockFixture.cs
@@ -1,0 +1,496 @@
+// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Core.Tests.TestUtils;
+using Uno.Threading;
+
+namespace Uno.Core.Tests.Threading
+{
+	[TestClass]
+	public class AsyncLockFixture
+	{
+		public TestContext TestContext { get; set; }
+
+#if DEBUG
+		private const TestTimeout _timeout = TestTimeout.Infinite;
+#else
+		private const int _timeout = 5000;
+#endif
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestUnlockReleaseNextSynchronously()
+		{
+			Console.WriteLine($"Running on thread {Thread.CurrentThread.ManagedThreadId}");
+
+			var sut = new FastAsyncLock();
+			var thread1ExitingThread = -1;
+			var thread2LockingTask = default(Task<IDisposable>);
+			var thread1 = new AsyncTestRunner(Thread1);
+			var thread2 = new AsyncTestRunner();
+			thread2.Run(Thread2);
+
+			using (thread1)
+			using (thread2)
+			{
+				// Acquire the lock on thread 1
+				await thread1.AdvanceTo(1);
+
+				// Wait for the thread 2 to be stuck to acquire the lock
+				var thread2Locking = thread2.AdvanceTo(1);
+				while (thread2LockingTask == null)
+				{
+					await Task.Yield();
+				}
+
+				// Make sure that the thread 2 is really awaiting the thread2LockingTask before requesting thread1 to continue
+				await Task.Delay(100);
+				Assert.AreEqual(TaskStatus.WaitingForActivation, thread2LockingTask.Status);
+
+				// Relase the thread 1 and make sure that the thread 2 is able to acquire the lock
+				var thread1Release = thread1.AdvanceTo(2);
+				await thread2Locking;
+			}
+
+			async Task Thread1(CancellationToken ct, AsyncTestRunner r)
+			{
+				Console.WriteLine($"Thread 1: {Thread.CurrentThread.ManagedThreadId}");
+
+				var ctx = AsyncTestContext.Current;
+				using (await sut.LockAsync(ct))
+				{
+					Console.WriteLine($"Acquired lock for Thread1 on thread: {Thread.CurrentThread.ManagedThreadId}");
+
+					ctx.Validate();
+					await Task.Yield();
+					r.Sync(position: 1);
+
+					thread1ExitingThread = Thread.CurrentThread.ManagedThreadId;
+					Console.WriteLine($"Releasing lock from Thread1 on thread: {Thread.CurrentThread.ManagedThreadId}");
+				}
+
+				Console.WriteLine($"Released lock from Thread1 on thread: {Thread.CurrentThread.ManagedThreadId}");
+
+				// This must have run synchronously when lock got released (disposed).
+				Assert.AreEqual(TaskStatus.RanToCompletion, thread2LockingTask.Status);
+
+				r.Sync(position: 2);
+			}
+
+			async Task Thread2(CancellationToken ct, AsyncTestRunner r)
+			{
+				Console.WriteLine($"Thread 2: {Thread.CurrentThread.ManagedThreadId}");
+
+				var ctx = AsyncTestContext.Current;
+
+				thread2LockingTask = sut.LockAsync(ct);
+
+				// Validate that we are running on thread 2
+				Assert.AreEqual(thread2.ThreadId, Thread.CurrentThread.ManagedThreadId);
+
+				Console.WriteLine("Thread 2 is waiting for lock");
+				using (await thread2LockingTask)
+				{
+					Console.WriteLine($"Acquired lock for Thread2 on thread: {Thread.CurrentThread.ManagedThreadId}");
+
+					// Here we should run on the thread 1 since the lock is released synchronously from thread 1
+					Assert.AreEqual(thread1ExitingThread, Thread.CurrentThread.ManagedThreadId);
+
+					// But we should have kept the ExecutionContext from the thread 2
+					ctx.Validate();
+
+					await Task.Yield();
+					r.Sync(position: 1);
+
+					Console.WriteLine($"Releasing lock from Thread2 on thread: {Thread.CurrentThread.ManagedThreadId}");
+				}
+
+				Console.WriteLine($"Released lock from Thread2 on thread: {Thread.CurrentThread.ManagedThreadId}");
+
+				r.Sync(position: 2);
+			}
+		}
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestConcurrentAccess()
+		{
+			var entryContext = AsyncTestContext.Current;
+			var sut = new FastAsyncLock();
+
+			using (var otherThread = new AsyncTestRunner(CommonTwoStepsLock(sut)))
+			{
+				// Acquire the lock on another async context
+				await otherThread.Advance(); 
+				Assert.IsTrue(otherThread.HasLock());
+
+				// Try to acquire the lock from this async context
+				entryContext.Validate();
+				var locking = sut.LockAsync(CancellationToken.None);
+				Assert.AreEqual(TaskStatus.WaitingForActivation, locking.Status);
+
+				await otherThread.Advance(); // Will release the lock
+				Assert.AreEqual(TaskStatus.RanToCompletion, locking.Status); // so lock is now acquired (sync)
+			}
+		}
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestConcurrentCancelSecond()
+		{
+			var entryContext = AsyncTestContext.Current;
+			var sut = new FastAsyncLock();
+			var ct = new CancellationTokenSource();
+
+			using (var otherThread = new AsyncTestRunner(CommonTwoStepsLock(sut)))
+			{
+				// Acquire the lock on another async context
+				await otherThread.Advance();
+				Assert.IsTrue(otherThread.HasLock());
+
+				// Try to acquire the lock from this async context
+				entryContext.Validate();
+				var locking = sut.LockAsync(ct.Token);
+				Assert.AreEqual(TaskStatus.WaitingForActivation, locking.Status);
+
+				// But cancel before the other async context completes
+				ct.Cancel();
+				Assert.AreEqual(TaskStatus.Canceled, locking.Status);
+			}
+		}
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestConcurrentCancelFirst()
+		{
+			var entryContext = AsyncTestContext.Current;
+			var sut = new FastAsyncLock();
+			var ct = new CancellationTokenSource();
+
+			using (var otherThread = new AsyncTestRunner(CommonTwoStepsLock(sut)))
+			{
+				// Acquire the lock on another async context
+				await otherThread.Advance();
+				Assert.IsTrue(otherThread.HasLock());
+
+				// Try to acquire the lock from this async context
+				entryContext.Validate();
+				var locking = sut.LockAsync(CancellationToken.None);
+				Assert.AreEqual(TaskStatus.WaitingForActivation, locking.Status);
+
+				// Cancel the CT of the other thread ... this should not impact the awaiter !
+				ct.Cancel();
+				Assert.AreEqual(TaskStatus.WaitingForActivation, locking.Status);
+
+				// Finally validate that if we release the lock from the other thread, we are still able to acquire the lock
+				await otherThread.Advance();
+				Assert.AreEqual(TaskStatus.RanToCompletion, locking.Status);
+			}
+		}
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestConcurrentCancelSecondWithThird()
+		{
+			var sut = new FastAsyncLock();
+			var ct = new CancellationTokenSource();
+
+			var thread2LockingTask = default(Task<IDisposable>);
+
+			using (var thread1 = new AsyncTestRunner(Thread1))
+			using (var thread2 = new AsyncTestRunner(Thread2))
+			using (var thread3 = new AsyncTestRunner(Thread3))
+			{
+				// Acquire the lock on thread 1 THEN 
+				await thread1.AdvanceTo(1);
+				Assert.IsTrue(thread1.HasLock());
+
+				// Try to acquire the lock from this async context
+				await thread2.AdvanceAndFreezeBefore(1);
+				//var locking = sut.LockAsync(ct.Token);
+				Assert.AreEqual(TaskStatus.WaitingForActivation, thread2LockingTask.Status);
+				Assert.IsFalse(thread2.HasLock());
+
+				// Try to acquire it on thread 3 
+				var t3Locked = thread3.AdvanceTo(1);
+				await thread3.IsFrozen();
+				Assert.IsFalse(thread3.HasLock());
+
+				// But cancel before the other async context completes
+				ct.Cancel();
+				Assert.AreEqual(TaskStatus.Canceled, thread2LockingTask.Status);
+
+				// Release the lock from thread1, and wait for thread 3 to acquire the lock
+				await thread1.AdvanceAndFreezeBefore(2); // will freeze in continuation of thread 3
+				await t3Locked;
+
+				//Assert.IsFalse(thread1.HasLock()); // flag not set yet: the thread 1 is dead locked by the continuation of thread 3
+				Assert.IsTrue(thread3.HasLock());
+
+				await thread3.AdvanceToEnd();
+				//await thread1.AdvanceToEnd();
+				await Task.Delay(500);
+
+				Assert.IsFalse(thread1.HasLock());
+				Assert.IsFalse(thread3.HasLock());
+			}
+
+
+			async Task Thread1(CancellationToken ct2, AsyncTestRunner r)
+			{
+				using (await sut.LockAsync(ct2))
+				{
+					r.HasLock(true);
+					r.Sync(position: 1);
+				}
+
+				r.HasLock(false);
+				r.Sync(position: 2);
+			};
+
+			async Task Thread2(CancellationToken ct2, AsyncTestRunner r)
+			{
+				thread2LockingTask = sut.LockAsync(ct.Token);
+				using (await thread2LockingTask)
+				{
+					r.HasLock(true);
+					r.Sync(position: 1);
+				}
+
+				r.HasLock(false);
+				r.Sync(position: 2);
+			}
+
+			async Task Thread3(CancellationToken ct2, AsyncTestRunner r)
+			{
+				using (await sut.LockAsync(ct2))
+				{
+					r.HasLock(true);
+					r.Sync(position: 1);
+				}
+
+				r.HasLock(false);
+				r.Sync(position: 2);
+			};
+		}
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestReEntrencySync()
+		{
+			var sut = new FastAsyncLock();
+			using (await sut.LockAsync(CancellationToken.None))
+			{
+				using (await sut.LockAsync(CancellationToken.None))
+				{
+				}
+			}
+		}
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestReEntrencyAsync()
+		{
+			var sut = new FastAsyncLock();
+			using (await sut.LockAsync(CancellationToken.None))
+			{
+				await Task.Yield();
+
+				using (await sut.LockAsync(CancellationToken.None))
+				{
+					await Task.Yield();
+				}
+			}
+		}
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestReEntrencyWithConcurrentAccess()
+		{
+			var sut = new FastAsyncLock();
+			using (var thread2 = new AsyncTestRunner(Thread2))
+			using (var thread1 = new AsyncTestRunner(Thread1))
+			{
+
+				// Enter from main thread
+				await thread1.AdvanceTo(1);
+
+				// Try enter from second thread
+				var thread2Locking = thread2.AdvanceTo(2);
+				await Task.Delay(100);
+				Assert.AreEqual(TaskStatus.WaitingForActivation, thread2Locking.Status);
+
+				// ReEnter
+				await thread1.AdvanceTo(2);
+
+				// Exit once
+				await thread1.AdvanceTo(3);
+				Assert.AreEqual(TaskStatus.WaitingForActivation, thread2Locking.Status);
+
+				// Final exit
+				thread1.AdvanceTo(4);
+				await thread2Locking;
+			}
+
+			async Task Thread1(CancellationToken ct, AsyncTestRunner r)
+			{
+				using (await sut.LockAsync(CancellationToken.None))
+				{
+					await Task.Yield();
+					r.HasLock(true);
+					r.Sync(position: 1);
+
+					using (await sut.LockAsync(CancellationToken.None))
+					{
+						await Task.Yield();
+						r.Sync(position: 2);
+					}
+
+					r.Sync(position: 3);
+				}
+
+				r.HasLock(false);
+				r.Sync(position: 4);
+			}
+
+			async Task Thread2(CancellationToken ct, AsyncTestRunner r)
+			{
+				using (await sut.LockAsync(ct))
+				{
+					r.HasLock(true);
+					r.Sync(position: 1);
+				}
+
+				r.HasLock(false);
+				r.Sync(position: 2);
+			}
+		}
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestReleaseThenReAcquire()
+		{
+			var sut = new FastAsyncLock();
+			using (await sut.LockAsync(CancellationToken.None))
+			{
+				await Task.Yield();
+			}
+
+			await Task.Yield();
+
+			using (await sut.LockAsync(CancellationToken.None))
+			{
+				await Task.Yield();
+			}
+		}
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestReleaseThenReAcquireWithConcurrentAccess()
+		{
+			var sut = new FastAsyncLock();
+			using (var otherThread = new AsyncTestRunner(OtherThread))
+			{
+				await otherThread.AdvanceTo(1);
+				Assert.IsTrue(otherThread.HasLock());
+
+				await otherThread.AdvanceTo(2);
+				Assert.IsFalse(otherThread.HasLock());
+
+				Task reLocking;
+				using (await sut.LockAsync(CancellationToken.None))
+				{
+					await Task.Yield();
+
+					reLocking = otherThread.AdvanceTo(3);
+					await Task.Delay(10);
+
+					Assert.AreEqual(TaskStatus.WaitingForActivation, reLocking.Status);
+				}
+
+				await reLocking;
+				Assert.IsTrue(otherThread.HasLock());
+			}
+
+			async Task OtherThread(CancellationToken ct, AsyncTestRunner r)
+			{
+				using (await sut.LockAsync(CancellationToken.None))
+				{
+					await Task.Yield();
+					r.HasLock(true);
+					r.Sync(position: 1);
+				}
+
+				await Task.Yield();
+				r.HasLock(false);
+				r.Sync(position: 2);
+
+				using (await sut.LockAsync(CancellationToken.None))
+				{
+					await Task.Yield();
+					r.HasLock(true);
+					r.Sync(position: 3);
+				}
+
+				await Task.Yield();
+				r.HasLock(false);
+				r.Sync(position: 4);
+			}
+		}
+
+		[TestMethod]
+		[Timeout(_timeout)]
+		public async Task TestMultipleDispose()
+		{
+			var sut = new FastAsyncLock();
+
+			var handle = await sut.LockAsync(CancellationToken.None);
+			handle.Dispose();
+			handle.Dispose();
+
+			// Validate that we can still acquire the lock
+			using (await sut.LockAsync(CancellationToken.None))
+			{
+			}
+		}
+
+		private static ActionAsync<AsyncTestRunner> CommonTwoStepsLock(FastAsyncLock @lock) => async (ct, r) =>
+		{
+			using (await @lock.LockAsync(ct))
+			{
+				r.HasLock(true);
+				r.Sync(position: 1);
+			}
+
+			r.HasLock(false);
+			r.Sync(position: 2);
+		};
+	}
+
+	internal static class RunnerExtensions
+	{
+		internal static bool HasLock(this AsyncTestRunner runner) => runner.Get<bool>("hasLock");
+
+		internal static void HasLock(this AsyncTestRunner runner, bool value) => runner.Set("hasLock", value);
+	}
+}

--- a/src/Uno.Core.Tests/Threading/FastTaskCompletionSourceFixture.cs
+++ b/src/Uno.Core.Tests/Threading/FastTaskCompletionSourceFixture.cs
@@ -1,0 +1,445 @@
+// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using System;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Reactive.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Core.Tests.TestUtils;
+using Uno.Threading;
+
+namespace Uno.Core.Tests.Threading
+{
+	[TestClass]
+	public class FastTaskCompletionSourceFixture
+	{
+		[TestMethod]
+		public void TestSetResultSynchronously1()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			sut.SetResult("1234");
+
+			// The task is created AFTER the result being set
+			var task = sut.Task;
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.RanToCompletion);
+			task.Result.Should().BeEquivalentTo("1234");
+		}
+
+		[TestMethod]
+		public void TestSetResultSynchronously2()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			// The task is created BEFORE the result being set
+			var task = sut.Task;
+			task.IsCompleted.Should().BeFalse();
+
+			sut.SetResult("1234");
+
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.RanToCompletion);
+			task.Result.Should().BeEquivalentTo("1234");
+		}
+
+		[TestMethod]
+		public void TestSetResultAsynchronously()
+		{
+			var scheduler = new TestScheduler();
+			var sut = new FastTaskCompletionSource<string>();
+
+			var threadId = Thread.CurrentThread.ManagedThreadId;
+
+			var task = scheduler
+				.Run(async ct =>
+				{
+					Thread.CurrentThread.ManagedThreadId.Should().Be(threadId);
+					var r = await sut.Task;
+					Thread.CurrentThread.ManagedThreadId.Should().Be(threadId);
+					return r;
+				}, CancellationToken.None);
+
+			task.IsCompleted.Should().BeFalse();
+			scheduler.AdvanceBy(5);
+
+			task.IsCompleted.Should().BeFalse();
+			sut.SetResult("1234");
+
+			scheduler.AdvanceBy(5);
+
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.RanToCompletion);
+			task.Result.Should().BeEquivalentTo("1234");
+
+			scheduler.Stop();
+		}
+
+		[TestMethod]
+		public void TestSetResultAsynchronously_AndAwaitDirectly1()
+		{
+			var scheduler = new TestScheduler();
+			var sut = new FastTaskCompletionSource<string>();
+
+			var threadId = Thread.CurrentThread.ManagedThreadId;
+
+			var task = scheduler
+				.Run(async ct =>
+				{
+					Thread.CurrentThread.ManagedThreadId.Should().Be(threadId);
+					var r = await sut;
+					Thread.CurrentThread.ManagedThreadId.Should().Be(threadId);
+					return r;
+				}, CancellationToken.None);
+
+			task.IsCompleted.Should().BeFalse();
+			scheduler.AdvanceBy(5);
+
+			task.IsCompleted.Should().BeFalse();
+			sut.SetResult("1234");
+
+			scheduler.AdvanceBy(5);
+
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.RanToCompletion);
+			task.Result.Should().BeEquivalentTo("1234");
+
+			scheduler.Stop();
+		}
+
+		[TestMethod]
+		public void TestSetResultAsynchronously_AndAwaitDirectly2()
+		{
+			var scheduler = new TestScheduler();
+			var sut = new FastTaskCompletionSource<string>();
+
+			var threadId = Thread.CurrentThread.ManagedThreadId;
+
+			sut.SetResult("1234");
+
+			scheduler.AdvanceBy(5);
+
+			var task = scheduler
+				.Run(async ct =>
+				{
+					Thread.CurrentThread.ManagedThreadId.Should().Be(threadId);
+					var r = await sut;
+					Thread.CurrentThread.ManagedThreadId.Should().Be(threadId);
+					return r;
+				}, CancellationToken.None);
+
+			scheduler.AdvanceBy(5);
+
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.RanToCompletion);
+			task.Result.Should().BeEquivalentTo("1234");
+
+			scheduler.Stop();
+		}
+
+		[TestMethod]
+		public void TestSetCanceledSynchronously1()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			sut.SetCanceled();
+
+			// The task is created AFTER the task being canceled
+			var task = sut.Task;
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.Canceled);
+		}
+
+		[TestMethod]
+		public void TestSetCanceledSynchronously2()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			// The task is created BEFORE the task being canceled
+			var task = sut.Task;
+			task.IsCompleted.Should().BeFalse();
+
+			sut.SetCanceled();
+
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.Canceled);
+		}
+
+		[TestMethod]
+		public void TestSetCanceledAsynchronously()
+		{
+			var scheduler = new TestScheduler();
+			var sut = new FastTaskCompletionSource<string>();
+
+			var threadId = Thread.CurrentThread.ManagedThreadId;
+
+			var task = scheduler
+				.Run(async ct =>
+				{
+					Thread.CurrentThread.ManagedThreadId.Should().Be(threadId);
+					await sut.Task;
+					throw new Exception("should not reach here");
+				}, CancellationToken.None);
+
+			task.IsCompleted.Should().BeFalse();
+			scheduler.AdvanceBy(5);
+
+			task.IsCompleted.Should().BeFalse();
+
+			sut.SetCanceled();
+
+			scheduler.AdvanceBy(5);
+
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.Canceled);
+
+			scheduler.Stop();
+		}
+
+		[TestMethod]
+		public void TestSetExceptionSynchronously1()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			try
+			{
+				throw new ArgumentNullException("xxx");
+			}
+			catch (ArgumentNullException ex)
+			{
+				sut.SetException(ex);
+			}
+
+			// The task is created AFTER the task being canceled
+			var task = sut.Task;
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.Faulted);
+			task.Exception.Should().NotBeNull();
+			var aggregateException = task.Exception;
+			aggregateException.InnerExceptions.Should().HaveCount(1);
+			var argException = aggregateException.InnerException;
+			argException.Should().BeOfType<ArgumentNullException>();
+			argException.TargetSite.Name.Should().BeEquivalentTo(nameof(TestSetExceptionSynchronously1), "original context is lost");
+
+		}
+
+		[TestMethod]
+		public void TestSetExceptionSynchronously2()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			// The task is created BEFORE the task being canceled
+			var task = sut.Task;
+			task.IsCompleted.Should().BeFalse();
+
+			try
+			{
+				throw new ArgumentNullException("xxx");
+			}
+			catch (ArgumentNullException ex)
+			{
+				sut.SetException(ex);
+			}
+
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.Faulted);
+			task.Exception.Should().NotBeNull();
+			var aggregateException = task.Exception;
+			aggregateException.InnerExceptions.Should().HaveCount(1);
+			var argException = aggregateException.InnerException;
+			argException.Should().BeOfType<ArgumentNullException>();
+			argException.TargetSite.Name.Should().BeEquivalentTo(nameof(TestSetExceptionSynchronously2), "original context is lost");
+		}
+
+		[TestMethod]
+		public void TestSetExceptionAsynchronously()
+		{
+			var scheduler = new TestScheduler();
+			var sut = new FastTaskCompletionSource<string>();
+
+			var threadId = Thread.CurrentThread.ManagedThreadId;
+
+			var task = scheduler
+				.Run(async ct =>
+				{
+					Thread.CurrentThread.ManagedThreadId.Should().Be(threadId);
+					await sut.Task;
+					throw new Exception("should not reach here");
+				}, CancellationToken.None);
+
+			task.IsCompleted.Should().BeFalse();
+			scheduler.AdvanceBy(5);
+
+			task.IsCompleted.Should().BeFalse();
+
+			try
+			{
+				throw new ArgumentNullException("xxx");
+			}
+			catch (ArgumentNullException ex)
+			{
+				sut.SetException(ex);
+			}
+
+			scheduler.AdvanceBy(5);
+
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.Faulted);
+			task.Exception.Should().NotBeNull();
+			var aggregateException = task.Exception;
+			aggregateException.InnerExceptions.Should().HaveCount(1);
+			var argException = aggregateException.InnerException;
+			argException.Should().BeOfType<ArgumentNullException>();
+			argException.TargetSite.Name.Should().BeEquivalentTo(nameof(TestSetExceptionAsynchronously), "original context is lost");
+
+			scheduler.Stop();
+		}
+
+		[TestMethod]
+		public void TestSetExceptionSynchronously_UsingExceptionDispatchInfo1()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			try
+			{
+				throw new ArgumentNullException("xxx");
+			}
+			catch (ArgumentNullException ex)
+			{
+				sut.SetException(ExceptionDispatchInfo.Capture(ex));
+			}
+
+			// The task is created AFTER the task being canceled
+			var task = sut.Task;
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.Faulted);
+			task.Exception.Should().NotBeNull();
+			var aggregateException = task.Exception;
+			aggregateException.InnerExceptions.Should().HaveCount(1);
+			var argException = aggregateException.InnerException;
+			argException.Should().BeOfType<ArgumentNullException>();
+			argException.TargetSite.Name.Should().BeEquivalentTo(nameof(TestSetExceptionSynchronously_UsingExceptionDispatchInfo1), "original context is lost");
+		}
+
+		[TestMethod]
+		public void TestSetExceptionSynchronously_UsingExceptionDispatchInfo2()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			// The task is created BEFORE the task being canceled
+			var task = sut.Task;
+			task.IsCompleted.Should().BeFalse();
+
+			try
+			{
+				throw new ArgumentNullException("xxx");
+			}
+			catch (ArgumentNullException ex)
+			{
+				sut.SetException(ExceptionDispatchInfo.Capture(ex));
+			}
+
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.Faulted);
+			task.Exception.Should().NotBeNull();
+			var aggregateException = task.Exception;
+			aggregateException.InnerExceptions.Should().HaveCount(1);
+			var argException = aggregateException.InnerException;
+			argException.Should().BeOfType<ArgumentNullException>();
+			argException.TargetSite.Name.Should().BeEquivalentTo(nameof(TestSetExceptionSynchronously_UsingExceptionDispatchInfo2), "original context is lost");
+		}
+
+		[TestMethod]
+		public void TestSetExceptionSynchronously_WithTaskCanceledException1()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			// The task is created BEFORE the task being canceled
+			var task = sut.Task;
+			task.IsCompleted.Should().BeFalse();
+
+			try
+			{
+				throw new TaskCanceledException("xxx");
+			}
+			catch (TaskCanceledException ex)
+			{
+				sut.SetException(ex);
+			}
+
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.Canceled);
+			task.Exception.Should().BeNull();
+		}
+
+		[TestMethod]
+		public void TestSetExceptionSynchronously_WithTaskCanceledException2()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			try
+			{
+				throw new TaskCanceledException("xxx");
+			}
+			catch (TaskCanceledException ex)
+			{
+				sut.SetException(ex);
+			}
+
+			// The task is created AFTER the task being canceled
+			var task = sut.Task;
+			task.IsCompleted.Should().BeTrue();
+			task.Status.Should().Be(TaskStatus.Canceled);
+			task.Exception.Should().BeNull();
+		}
+
+		[TestMethod]
+		public void TestSetResultTwice_ThrowException()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			Action action = () => sut.SetResult("1234");
+
+			action.Should().NotThrow();
+			action.Should().Throw<InvalidOperationException>();
+		}
+
+		[TestMethod]
+		public void TestSetCanceledTwice_ThrowException()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			Action action = () => sut.SetCanceled();
+
+			action.Should().NotThrow();
+			action.Should().Throw<InvalidOperationException>();
+		}
+
+		[TestMethod]
+		public void TestSetExceptionTwice_ThrowException()
+		{
+			var sut = new FastTaskCompletionSource<string>();
+
+			Action action = () => sut.SetException(new ArgumentNullException("xxx"));
+
+			action.Should().NotThrow();
+			action.Should().Throw<InvalidOperationException>();
+		}
+	}
+}

--- a/src/Uno.Core.Tests/Uno.Core.Tests.csproj
+++ b/src/Uno.Core.Tests/Uno.Core.Tests.csproj
@@ -8,6 +8,7 @@
 	<ItemGroup>
 		<PackageReference Include="Funq" Version="1.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Reactive.Testing" Version="3.1.1" />
 		<PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
 		<PackageReference Include="FluentAssertions" Version="5.1.2" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/src/Uno.Core.Tests/_TestUtils/AsyncTestContext.cs
+++ b/src/Uno.Core.Tests/_TestUtils/AsyncTestContext.cs
@@ -1,0 +1,54 @@
+// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using System;
+using System.Linq;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.Core.Tests.TestUtils
+{
+	public class AsyncTestContext
+	{
+		private static long _nextId;
+		private static readonly AsyncLocal<AsyncTestContext> _context = new AsyncLocal<AsyncTestContext>();
+
+		public long Id { get; } = Interlocked.Increment(ref _nextId);
+
+		public static AsyncTestContext Current
+		{
+			get
+			{
+				var context = _context.Value;
+				if (context == null)
+				{
+					_context.Value = context = new AsyncTestContext();
+				}
+
+				return context;
+			}
+		}
+
+		private AsyncTestContext()
+		{
+		}
+
+		public void Validate()
+		{
+			Assert.AreEqual(this, _context.Value);
+		}
+	}
+}

--- a/src/Uno.Core.Tests/_TestUtils/AsyncTestRunner.cs
+++ b/src/Uno.Core.Tests/_TestUtils/AsyncTestRunner.cs
@@ -1,0 +1,350 @@
+// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Threading;
+
+namespace Uno.Core.Tests.TestUtils
+{
+	public class AsyncTestRunner : IDisposable
+	{
+#if DEBUG
+		private const int _beatTimeout = 10*1000;
+#else
+		private const int _beatTimeout = 100;
+#endif
+
+		private readonly bool _loop;
+		private static ImmutableList<AsyncTestRunner> _runners = ImmutableList<AsyncTestRunner>.Empty;
+
+		private readonly CancellationTokenSource _ct = new CancellationTokenSource();
+		private readonly AutoResetEvent _syncEvent = new AutoResetEvent(initialState: false);
+		private readonly AutoResetEvent _queueEvent = new AutoResetEvent(initialState: false);
+		private readonly ManualResetEventSlim _exited = new ManualResetEventSlim(initialState: false);
+
+		private readonly string _identifier;
+
+		private ImmutableQueue<QueueItem> _queue = ImmutableQueue<QueueItem>.Empty;
+		private QueueItem _current;
+		private Thread _thread;
+		private bool _isStopped;
+		private SyncFlag _syncFlag;
+		private int _syncPosition;
+		private ImmutableDictionary<string , object> _interopValues = ImmutableDictionary<string, object>.Empty;
+
+		public AsyncTestRunner(ActionAsync<AsyncTestRunner> method = null, [CallerMemberName] string name = null, [CallerLineNumber] int line = -1, bool loop = false)
+		{
+			_loop = loop;
+			_identifier = $"{name}@{line}";
+			ImmutableInterlocked.Update(ref _runners, r => r.Add(this));
+
+			if (method != null)
+			{
+				Run(method);
+			}
+		}
+
+		public int ThreadId => _thread.ManagedThreadId;
+
+		public T Get<T>(string key, T defaultValue = default(T)) => _interopValues.TryGetValue(key, out var value) ? (T)value : defaultValue;
+
+		public void Set<T>(string key, T value) => ImmutableInterlocked.Update(ref _interopValues, values => values.SetItem(key, value));
+
+		public Task Run(ActionAsync<AsyncTestRunner> method)
+		{
+			var item = new QueueItem(method);
+			ImmutableInterlocked.Enqueue(ref _queue, item);
+
+			if (_thread == null)
+			{
+				var thread = new Thread(RunLoop);
+				if (Interlocked.CompareExchange(ref _thread, thread, null) == null)
+				{
+					thread.Start();
+				}
+			}
+			else
+			{
+				_queueEvent.Set();
+			}
+
+			return item.Task;
+		}
+
+		private async void RunLoop()
+		{
+			try
+			{
+				while (!_isStopped)
+				{
+					while (ImmutableInterlocked.TryDequeue(ref _queue, out _current))
+					{
+						try
+						{
+							SyncCore();
+							await _current.Run(this);
+
+							Interlocked.Exchange(ref _interopValues, ImmutableDictionary<string, object>.Empty);
+							Interlocked.Exchange(ref _syncFlag, null)?.Reached(int.MaxValue);
+							Interlocked.Exchange(ref _syncPosition, 0);
+						}
+						catch (ObjectDisposedException ode) when (ode.ObjectName == nameof(AsyncTestRunner))
+						{
+						}
+						catch (OperationCanceledException)
+						{
+						}
+						catch (Exception e)
+						{
+							foreach (var runner in _runners.Except(new [] {this}))
+							{
+								runner.Abort($"****ANOTHER**** Test runner ({_identifier}) failed with: {e.Message}");
+							}
+
+							Abort(e);
+
+							throw;
+						}
+					}
+
+					if (_isStopped || !_loop)
+					{
+						return;
+					}
+
+					_queueEvent.WaitOne();
+				}
+			}
+			finally
+			{
+				_exited.Set();
+				Dispose();
+			}
+		}
+
+		public void Sync() => Sync(_syncPosition +1);
+
+		public void Sync(int position)
+		{
+			_current?.Beat();
+
+			var previousPosition = Interlocked.Exchange(ref _syncPosition, position);
+			if (previousPosition > position)
+			{
+				throw new InvalidOperationException("Sync index is lower than the previous");
+			}
+
+			var currentFlag = _syncFlag;
+			if (currentFlag == null
+				|| position < currentFlag.Position)
+			{
+				// continue
+			}
+			else if (position == currentFlag.Position)
+			{
+				currentFlag.Reached(position);
+
+				SyncCore();
+			}
+			else //if (position > currentFlag.Position)
+			{
+				throw new InvalidOperationException("We missed a sync flag!");
+			}
+		}
+
+		private void SyncCore()
+		{
+			_current?.Beat();
+
+			_syncEvent.WaitOne();
+
+			if (_isStopped)
+			{
+				// Make sure the works does not continue
+				throw new ObjectDisposedException(nameof(AsyncTestRunner));
+			}
+
+			_current?.Beat();
+		}
+
+		public Task IsFrozen() => _current?.Frozen();
+
+		public Task Advance() => AdvanceTo(_syncPosition + 1);
+
+		public Task AdvanceToEnd() => AdvanceTo(int.MaxValue);
+
+		public Task AdvanceTo(int position)
+		{
+			var flag = new SyncFlag(position);
+			Interlocked.Exchange(ref _syncFlag, flag)?.Canceled();
+			if (position <= _syncPosition)
+			{
+				throw new InvalidOperationException("Thread is already at positon " + _syncPosition);
+			}
+
+			_syncEvent.Set();
+
+			return flag.Wait();
+		}
+
+		public async Task AdvanceAndFreezeBefore(int position)
+		{
+			var flag = new SyncFlag(position);
+			Interlocked.Exchange(ref _syncFlag, flag)?.Canceled();
+			if (position <= _syncPosition)
+			{
+				throw new InvalidOperationException("Thread is already at positon " + _syncPosition);
+			}
+
+			_syncEvent.Set();
+
+			var reached = flag.Wait();
+			var frozen = _current.Frozen();
+
+			await Task.WhenAny(reached, frozen);
+
+			Assert.AreEqual(TaskStatus.WaitingForActivation, reached.Status);
+			Assert.AreEqual(TaskStatus.RanToCompletion, frozen.Status);
+		}
+
+		private void Abort(object reason)
+		{
+			AbortSafe(reason as Exception ?? new Exception(reason.ToString()));
+
+			_thread.Abort(reason);
+			_exited.Set();
+		}
+
+		private void AbortSafe(Exception reason)
+		{
+			if (_isStopped)
+			{
+				return;
+			}
+
+			ImmutableInterlocked.Update(ref _runners, r => r.Remove(this));
+
+			try { _syncEvent.Set(); } catch (ObjectDisposedException) { }
+			try { _queueEvent.Set(); } catch (ObjectDisposedException) { }
+
+			try { _syncEvent.Dispose(); } catch (ObjectDisposedException) { }
+			try { _queueEvent.Dispose(); } catch (ObjectDisposedException) { }
+
+			try { _ct.Cancel(); } catch (ObjectDisposedException) { }
+			try { _ct.Dispose(); } catch (ObjectDisposedException) { }
+
+			_current?.Fail(reason);
+			_syncFlag?.Failed(reason);
+			foreach (var item in _queue)
+			{
+				item.Abort();
+			}
+
+			_isStopped = true;
+		}
+
+		public void Dispose()
+		{
+			AbortSafe(new ObjectDisposedException(nameof(AsyncTestRunner)));
+
+			if (_thread.IsAlive)
+			{
+				_exited.Wait();
+			}
+		}
+
+		private class QueueItem
+		{
+			private readonly ActionAsync<AsyncTestRunner> _method;
+			private readonly FastTaskCompletionSource<Unit> _task = new FastTaskCompletionSource<Unit>();
+
+			private DateTime _lastBeat = DateTime.Now;
+
+			public QueueItem(ActionAsync<AsyncTestRunner> method)
+			{
+				_method = method;
+			}
+
+			public void Beat()
+			{
+				_lastBeat = DateTime.Now;
+			}
+
+			public async Task Frozen()
+			{
+				var delay = _lastBeat.AddMilliseconds(_beatTimeout) - DateTime.Now;
+				if (delay > TimeSpan.Zero)
+				{
+					await Task.Delay(delay);
+				}
+				else
+				{
+					await Task.Yield();
+				}
+			}
+
+			public async Task Run(AsyncTestRunner runner)
+			{
+				try
+				{
+					await _method(runner._ct.Token, runner);
+					_task.TrySetResult(Unit.Default);
+				}
+				catch (Exception e)
+				{
+					_task.TrySetException(e);
+
+					throw;
+				}
+			}
+
+			public void Fail(Exception e) => _task.TrySetException(e);
+
+			public void Abort() => _task.TrySetCanceled();
+
+			public Task Task => _task.Task;
+		}
+
+		private class SyncFlag
+		{
+			private readonly FastTaskCompletionSource<int> _task = new FastTaskCompletionSource<int>();
+
+			public SyncFlag(int position)
+			{
+				Position = position;
+			}
+
+			public int Position { get; }
+
+			public Task Wait() => _task.Task;
+
+			public void Reached(int position) => Task.Run(() => _task.TrySetResult(position)); // Ensure that awaiter does not run on this thread!
+
+			public void Failed(Exception e) => _task.TrySetException(e);
+
+			public void Canceled() => _task.TrySetCanceled();
+		}
+	}
+}

--- a/src/Uno.Core.Tests/_TestUtils/SchedulerExtensions.cs
+++ b/src/Uno.Core.Tests/_TestUtils/SchedulerExtensions.cs
@@ -1,0 +1,85 @@
+// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using System;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Threading;
+
+namespace Uno.Core.Tests.TestUtils
+{
+	internal static class SchedulerExtensions
+	{
+		/// <summary>
+		/// Awaits a task execution on the specified scheduler, providing the result.
+		/// </summary>
+		/// <returns>A task that will provide the result of the execution.</returns>
+		public static Task<T> Run<T>(this IScheduler source, Func<CancellationToken, Task<T>> taskBuilder, CancellationToken cancellationToken)
+		{
+			var completion = new FastTaskCompletionSource<T>();
+
+			var disposable = new SingleAssignmentDisposable();
+			var ctr = default(CancellationTokenRegistration);
+
+			if (cancellationToken.CanBeCanceled)
+			{
+				ctr = cancellationToken.Register(() =>
+				{
+					completion.TrySetCanceled();
+					disposable.Dispose();
+				});
+			}
+
+			disposable.Disposable = source.Schedule(
+				async () =>
+				{
+					try
+					{
+						var result = await taskBuilder(cancellationToken);
+						completion.TrySetResult(result);
+					}
+					catch (Exception e)
+					{
+						completion.TrySetException(e);
+					}
+					finally
+					{
+						ctr.Dispose();
+					}
+				}
+			);
+
+			return completion.Task;
+		}
+
+		/// <summary>
+		/// Awaits a task on the specified scheduler, without providing a result.
+		/// </summary>
+		/// <returns>A task that will complete when the work has completed.</returns>
+		public static Task Run(this IScheduler source, Func<CancellationToken, Task> taskBuilder, CancellationToken ct)
+		{
+			return Run(
+				source,
+				async ct2 => { await taskBuilder(ct2); return Unit.Default; },
+				ct
+			);
+		}
+	}
+}

--- a/src/Uno.Core/Threading/AsyncLock.md
+++ b/src/Uno.Core/Threading/AsyncLock.md
@@ -1,0 +1,52 @@
+# Async Lock
+
+## Concept
+The idea of the `AsyncLock` is to provide an asynchronous equivalent of the `lock` keyword, in order to protect a ressource while working asynchronously.
+
+## Usage
+```csharp
+1: using (await gate.LockAsync(ct))
+2: {
+3:	// Safe section
+4:	await something;
+5: }
+6: // Continuation
+```
+
+## FastAsyncLock
+The `FastAsyncLock` has the same contract of the `AsyncLock` but it differs on two points:
+
+1. It allows re-entrency
+1. When releasing the lock, next awaiters are run synchronously
+
+While the first point is pretty obvious, the second point is more tricky. Lets assume the example: *Task #1* acquired the lock (line 3 in example above), while *Task #2* is waiting for it (line 1).
+
+With the `AsyncLock` when the thread that is running *Task #1* releases the lock, it will schedule on the `TaskScheduler` the continuation of the *Task #2* while it continues to execute *Task #1*.
+
+With the `FastAsyncLock` will instead continue *Task #2* (i.e. entering in the safe section of the *Task #2*) **before** continuing the *Task #1*
+
+
+### `AsyncLock`
+
+|  Main thread		| *any available thread of task pool* | *any available thread of task pool* |
+| ----------------- | ----------------- |  -------------------- |
+| line 3 of task #1 |					| 						|
+| line 4 of task #1 |					| 						|
+| line 5 of task #1 |					| 						|
+| line 6 of task #1 | line 2 of task #2 | 						|
+|					| line 3 of task #2 | 						|
+|					| line 4 of task #2 | 						|
+|					| 					| something of task #2	|
+
+
+### `FastAsyncLock`
+
+|  Main thread		| *any available thread of task pool* |
+| ----------------- | --------------------- |
+| line 3 of task #1 |						|
+| line 4 of task #1 |						|
+| line 5 of task #1 |						|
+| line 2 of task #2 |						|
+| line 3 of task #2 |						|
+| line 4 of task #2 |						|
+| line 6 of task #1 | something	of task #2	|

--- a/src/Uno.Core/Threading/FastAsyncLock.cs
+++ b/src/Uno.Core/Threading/FastAsyncLock.cs
@@ -1,0 +1,238 @@
+﻿// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Uno.Threading
+{
+	/// <summary>
+	/// An re-entrant asynchronous lock, that can be used in conjuction with C# async/await
+	/// </summary>
+	public sealed class FastAsyncLock
+	{
+		private readonly AsyncLocal<AsyncLocalMonitor> _localMonitor = new AsyncLocal<AsyncLocalMonitor>();
+
+		private AsyncLocalMonitor _tail;
+
+		/// <summary>
+		/// Acquires the lock, then provides a disposable to release it.
+		/// </summary>
+		/// <param name="ct">A cancellation token to cancel the acquisition of the lock</param>
+		/// <returns>An IDisposable instance that allows the release of the lock.</returns>
+		public Task<IDisposable> LockAsync(CancellationToken ct)
+		{
+			var monitor = _localMonitor.Value;
+			if (monitor?.TryReEnterSync() ?? false)
+			{
+				// If the node from the async local is not null, it means that the current 'ExecutionContext' already acquired the lock.
+				// Check if we can re-enter (if the lock was not released yet), and if so continue with current monitor.
+				return Task.FromResult<IDisposable>(new Handle(monitor));
+			}
+
+			// Creates a new monitor and set it on current 'ExecutionContext' to allow re-entrency
+			_localMonitor.Value = monitor = new AsyncLocalMonitor(this);
+
+			// Then enqueue this new monitor
+			var previous = Interlocked.Exchange(ref _tail, monitor);
+			if (previous?.TryEnqueue(monitor) ?? false)
+			{
+				// The lock was already aquired by someone else, add us into the queue
+				return monitor.EnterAsync(ct);
+			}
+			else 
+			{
+				// The waiting queue was empty (or the previous node is already completed)
+				// Tt means that we sucessfully acquired the lock
+				return Task.FromResult(monitor.EnterSync());
+			}
+		}
+
+		private class AsyncLocalMonitor
+		{
+			private readonly FastAsyncLock _owner;
+
+			private int _state = State.Waiting;
+			private FastTaskCompletionSource<IDisposable> _enterAsync;
+			private int _count;
+			private AsyncLocalMonitor _next;
+
+			private static class State
+			{
+				public const int Waiting = 0;
+				public const int Entered = 1;
+				public const int Exited = 2;
+				public const int Aborted = int.MaxValue;
+			}
+
+			public AsyncLocalMonitor(FastAsyncLock owner)
+			{
+				_owner = owner;
+			}
+
+			public IDisposable EnterSync()
+			{
+				// No concurrency consideration: we are on a single 'ExecutionContext' (i.e. on a single thread at a time)
+
+				Debug.Assert(_count == 0);
+				Debug.Assert(_state == State.Waiting);
+
+				_count = 1;
+				_state = State.Entered;
+
+				return new Handle(this);
+			}
+
+			public bool TryReEnterSync()
+			{
+				// No concurrency consideration: we are on a single 'ExecutionContext' (i.e. on a single thread at a time)
+
+				switch (_state)
+				{
+					case State.Waiting:
+						throw new InvalidOperationException("'ExecutionContext' corrupted.");
+
+					case State.Entered:
+						_count++;
+						return true;
+
+					case State.Aborted:
+					case State.Exited:
+						return false;
+
+					default:
+						throw new InvalidOperationException("Invalid state.");
+				}
+			}
+
+			public Task<IDisposable> EnterAsync(CancellationToken ct)
+			{
+				// The item may have been already dequeued by the previous since it was set as '_next',
+				// If so, return sync (note: the '_count' was already incremented)
+				if (_state == State.Waiting)
+				{
+					_enterAsync = new FastTaskCompletionSource<IDisposable>();
+
+					if (ct.CanBeCanceled)
+					{
+						_enterAsync.OnCompleted(ct.Register(Abort).Dispose);
+
+						void Abort()
+						{
+							if (Interlocked.CompareExchange(ref _state, State.Aborted, State.Waiting) == State.Waiting)
+							{
+								_enterAsync.SetCanceled();
+							}
+						}
+					}
+
+					// This instance may have been dequeued by previous while we where initiazing the async hanlde,
+					// so make sure to not wait a task that will never complete.
+					if (_state == State.Waiting)
+					{
+						return _enterAsync.Task;
+					}
+				}
+
+				return Task.FromResult<IDisposable>(new Handle(this));
+			}
+
+			private void Dequeued()
+			{
+				// Dequeing may occures more than once. So move to next step only if item is really waiting!
+				switch (Interlocked.CompareExchange(ref _state, State.Entered, State.Waiting))
+				{
+					case State.Waiting:
+						_count = 1;
+						_enterAsync?.SetResult(new Handle(this)); // null check: item may be dequeued even if EnterAsync was not yet invoked
+						break;
+
+					case State.Aborted:
+						_next?.Dequeued();
+						break;
+				}
+			}
+
+			public bool TryEnqueue(AsyncLocalMonitor next)
+			{
+				Debug.Assert(_next == null);
+
+				if (_state >= State.Exited)
+				{
+					return false;
+				}
+
+				// First set item as '_next'
+				_next = next;
+				if (_state >= State.Exited)
+				{
+					// It may occures that this monitor is being exited while we where setting '_next'.
+					// If so, make sure that the '_next' is being dequeued.
+					// Note: This may conduct the item to be 'Dequeued' twice (if it was already set while exiting, '_next' has already been dequeued)
+
+					_next.Dequeued();
+				}
+
+				return true;
+			}
+
+			public void Exit()
+			{
+				// Dispose is allowed only from the same ExecutionContext.
+				if (_owner._localMonitor.Value != this)
+				{
+					throw new SynchronizationLockException("AsyncLock was not acquired for the current ExecutionContext");
+				}
+
+				// Starting from here, no concurrency consideration: we are on a single 'ExecutionContext' (i.e. on a single thread at a time)
+
+				if (--_count == 0)
+				{
+					// Validate that the awaiter was not aborted
+					if (Interlocked.CompareExchange(ref _state, State.Exited, State.Entered) == State.Entered)
+					{
+						_next?.Dequeued();
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// An handle on an async lock which makes sure that disposing it mutiple times won't exit the monitor multiple times
+		/// </summary>
+		private class Handle : IDisposable
+		{
+			private readonly AsyncLocalMonitor _awaiter;
+			private int _isDisposed;
+
+			public Handle(AsyncLocalMonitor awaiter)
+			{
+				_awaiter = awaiter;
+			}
+
+			public void Dispose()
+			{
+				if (Interlocked.Exchange(ref _isDisposed, 1) == 0)
+				{
+					_awaiter.Exit();
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Compared to `AsyncLock`, it
- Ensure to continue other awaiters synchronously instead of releasing them on an uncontrolled context.
- Allow re-entrency
Also
- Import tests of the `FastTaskCompletionSource`