### PR TITLE
Fix FastTaskCompletionSource may not running continuations synchronously

### DIFF
--- a/src/Uno.Core/Threading/FastTaskCompletionSource.cs
+++ b/src/Uno.Core/Threading/FastTaskCompletionSource.cs
@@ -364,7 +364,25 @@ namespace Uno.Threading
 
 		private async Task<T> CreateAsyncTask()
 		{
-			return await this;
+			var originalContext = SynchronizationContext.Current;
+			try
+			{
+				SynchronizationContext.SetSynchronizationContext(ImmediatePostSyncContext.Instance);
+
+				return await this;
+			}
+			finally
+			{
+				SynchronizationContext.SetSynchronizationContext(originalContext);
+			}
+		}
+
+		private class ImmediatePostSyncContext : SynchronizationContext
+		{
+			public static ImmediatePostSyncContext Instance { get; } = new ImmediatePostSyncContext();
+
+			/// <inheritdoc />
+			public override void Post(SendOrPostCallback action, object state) => action(state);
 		}
 	}
 }


### PR DESCRIPTION
Fix FastTaskCompletionSource not running continuations synchronously if the SyncContext of completion is not the same as the captured one when creating the task.