### PR TITLE
Remove catch filter clause for mono-wasm compatibility

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -1,6 +1,6 @@
 #addin "Cake.FileHelpers"
 #addin "Cake.Powershell"
-#tool "nuget:?package=GitVersion.CommandLine"
+#tool "nuget:?package=GitVersion.CommandLine&version=3.6.5" 
 
 using System;
 using System.Linq;

--- a/src/Uno.Core/Logging/LogExtensionPoint.cs
+++ b/src/Uno.Core/Logging/LogExtensionPoint.cs
@@ -67,13 +67,20 @@ namespace Uno.Extensions
 
 					throw new InvalidOperationException($"The service {service?.GetType()} is not of type ILoggerFactory.");
 				}
-				catch (Exception e) when (e is NullReferenceException || e is InvalidOperationException)
+				catch (Exception e)
 				{
+					if (e is NullReferenceException || e is InvalidOperationException)
+					{
 #if HAS_CONSOLE
-					Console.WriteLine("***** WARNING *****");
-					Console.WriteLine("Unable to get the service locator ({0}), using the default logger to System.Diagnostics.Debug", e.Message);
+						Console.WriteLine("***** WARNING *****");
+						Console.WriteLine("Unable to get the service locator ({0}), using the default logger to System.Diagnostics.Debug", e.Message);
 #endif
-					return new LoggerFactory();
+						return new LoggerFactory();
+					}
+					else
+					{
+						throw;
+					}
 				}
 			}
 			else


### PR DESCRIPTION
This filter is not useful, and can be implemented as catch/rethrow.