### PR TITLE
Adds Trace and Critical to the log extensions.

### DIFF
--- a/src/Uno.Core/Logging/LogExtensions.cs
+++ b/src/Uno.Core/Logging/LogExtensions.cs
@@ -20,358 +20,532 @@ using System.Globalization;
 
 namespace Uno.Logging
 {
-    public static partial class LogExtensions
-    {
-        /// <summary>
-        /// Send a "Debug" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsDebugEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// </remarks>
-        public static void DebugFormat(this ILogger log, object message)
-        {
+	public static partial class LogExtensions
+	{
+		/// <summary>
+		/// Send a "Trace" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsTraceEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void TraceFormat(this ILogger log, object message)
+		{
+			log.Log<object>(LogLevel.Trace, 0, null, null, (_, __) => message?.ToString());
+		}
+
+		/// <summary>
+		/// Send a "Trace" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsTraceEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void TraceFormat(this ILogger log, string format, object arg0)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0);
+			log.Log<object>(LogLevel.Trace, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a "Trace" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsTraceEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void TraceFormat(this ILogger log, string format, object arg0, object arg1)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1);
+			log.Log<object>(LogLevel.Trace, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a "Trace" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsTraceEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void TraceFormat(this ILogger log, string format, object arg0, object arg1, object arg2)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1, arg2);
+			log.Log<object>(LogLevel.Trace, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a "Trace" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsTraceEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void TraceFormat(this ILogger log, string format, params object[] args)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, args);
+			log.Log<object>(LogLevel.Trace, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a "Trace" message to configured loggers.
+		/// </summary>
+		public static void Trace(this ILogger log, string message, Exception exception = null)
+		{
+			log.Log<object>(LogLevel.Trace, 0, null, exception, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a "Trace" message to configured loggers using a deferred action to build the message,
+		/// if the Trace log level is enabled.
+		/// </summary>
+		public static void Trace(this ILogger log, Func<object> messageBuilder, Exception exception = null)
+		{
+			if (log.IsEnabled(LogLevel.Trace))
+			{
+				log.Log<object>(LogLevel.Trace, 0, null, exception, (_, __) => messageBuilder()?.ToString());
+			}
+		}
+
+		/// <summary>
+		/// Send a "Debug" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsDebugEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void DebugFormat(this ILogger log, object message)
+		{
 			log.Log<object>(LogLevel.Debug, 0, null, null, (_, __) => message?.ToString());
 		}
 
-        /// <summary>
-        /// Send a "Debug" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsDebugEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// </remarks>
-        public static void DebugFormat(this ILogger log, string format, object arg0)
-        {
+		/// <summary>
+		/// Send a "Debug" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsDebugEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void DebugFormat(this ILogger log, string format, object arg0)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, arg0);
 			log.Log<object>(LogLevel.Debug, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Debug" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsDebugEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// </remarks>
-        public static void DebugFormat(this ILogger log, string format, object arg0, object arg1)
-        {
+		/// <summary>
+		/// Send a "Debug" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsDebugEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void DebugFormat(this ILogger log, string format, object arg0, object arg1)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1);
 			log.Log<object>(LogLevel.Debug, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Debug" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsDebugEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// </remarks>
-        public static void DebugFormat(this ILogger log, string format, object arg0, object arg1, object arg2)
-        {
+		/// <summary>
+		/// Send a "Debug" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsDebugEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void DebugFormat(this ILogger log, string format, object arg0, object arg1, object arg2)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1, arg2);
 			log.Log<object>(LogLevel.Debug, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Debug" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsDebugEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// </remarks>
-        public static void DebugFormat(this ILogger log, string format, params object[] args)
-        {
+		/// <summary>
+		/// Send a "Debug" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsDebugEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void DebugFormat(this ILogger log, string format, params object[] args)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, args);
 			log.Log<object>(LogLevel.Debug, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Debug" message to configured loggers.
-        /// </summary>
-        public static void Debug(this ILogger log, string message, Exception exception = null)
-        {
+		/// <summary>
+		/// Send a "Debug" message to configured loggers.
+		/// </summary>
+		public static void Debug(this ILogger log, string message, Exception exception = null)
+		{
 			log.Log<object>(LogLevel.Debug, 0, null, exception, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Debug" message to configured loggers using a deferred action to build the message,
-        /// if the Debug log level is enabled.
-        /// </summary>
-        public static void Debug(this ILogger log, Func<object> messageBuilder, Exception exception = null)
-        {
+		/// <summary>
+		/// Send a "Debug" message to configured loggers using a deferred action to build the message,
+		/// if the Debug log level is enabled.
+		/// </summary>
+		public static void Debug(this ILogger log, Func<object> messageBuilder, Exception exception = null)
+		{
 			if (log.IsEnabled(LogLevel.Debug))
 			{
 				log.Log<object>(LogLevel.Debug, 0, null, exception, (_, __) => messageBuilder()?.ToString());
 			}
 		}
 
-        /// <summary>
-        /// Send a "Info" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsInfoEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Info" is usually always available.
-        /// </remarks>
-        public static void InfoFormat(this ILogger log, object message)
-        {
+		/// <summary>
+		/// Send a "Info" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsInfoEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Info" is usually always available.
+		/// </remarks>
+		public static void InfoFormat(this ILogger log, object message)
+		{
 			log.Log<object>(LogLevel.Information, 0, null, null, (_, __) => message?.ToString());
 		}
 
-        /// <summary>
-        /// Send a "Info" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsInfoEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Info" is usually always available.
-        /// </remarks>
-        public static void InfoFormat(this ILogger log, string format, object arg0)
-        {
+		/// <summary>
+		/// Send a "Info" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsInfoEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Info" is usually always available.
+		/// </remarks>
+		public static void InfoFormat(this ILogger log, string format, object arg0)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, arg0);
 			log.Log<object>(LogLevel.Information, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Info" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsInfoEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Info" is usually always available.
-        /// </remarks>
-        public static void InfoFormat(this ILogger log, string format, object arg0, object arg1)
-        {
+		/// <summary>
+		/// Send a "Info" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsInfoEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Info" is usually always available.
+		/// </remarks>
+		public static void InfoFormat(this ILogger log, string format, object arg0, object arg1)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1);
 			log.Log<object>(LogLevel.Information, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Info" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsInfoEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Info" is usually always available.
-        /// </remarks>
-        public static void InfoFormat(this ILogger log, string format, object arg0, object arg1, object arg2)
-        {
+		/// <summary>
+		/// Send a "Info" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsInfoEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Info" is usually always available.
+		/// </remarks>
+		public static void InfoFormat(this ILogger log, string format, object arg0, object arg1, object arg2)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1, arg2);
 			log.Log<object>(LogLevel.Information, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Info" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsInfoEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Info" is usually always available.
-        /// </remarks>
-        public static void InfoFormat(this ILogger log, string format, params object[] args)
-        {
+		/// <summary>
+		/// Send a "Info" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsInfoEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Info" is usually always available.
+		/// </remarks>
+		public static void InfoFormat(this ILogger log, string format, params object[] args)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, args);
 			log.Log<object>(LogLevel.Information, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Info" message to configured loggers.
-        /// </summary>
-        public static void Info(this ILogger log, string message, Exception exception = null)
-        {
+		/// <summary>
+		/// Send a "Info" message to configured loggers.
+		/// </summary>
+		public static void Info(this ILogger log, string message, Exception exception = null)
+		{
 			log.Log<object>(LogLevel.Information, 0, null, exception, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Info" message to configured loggers using a deferred action to build the message,
-        /// if the Info log level is enabled.
-        /// </summary>
-        public static void Info(this ILogger log, Func<object> messageBuilder, Exception exception = null)
-        {
+		/// <summary>
+		/// Send a "Info" message to configured loggers using a deferred action to build the message,
+		/// if the Info log level is enabled.
+		/// </summary>
+		public static void Info(this ILogger log, Func<object> messageBuilder, Exception exception = null)
+		{
 			if (log.IsEnabled(LogLevel.Information))
 			{
 				log.Log<object>(LogLevel.Information, 0, null, exception, (_, __) => messageBuilder()?.ToString());
 			}
 		}
 
-        /// <summary>
-        /// Send a "Warn" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsWarnEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Warn" is usually always available.
-        /// </remarks>
-        public static void WarnFormat(this ILogger log, object message)
-        {
+		/// <summary>
+		/// Send a "Warn" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsWarnEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Warn" is usually always available.
+		/// </remarks>
+		public static void WarnFormat(this ILogger log, object message)
+		{
 			log.Log<object>(LogLevel.Warning, 0, null, null, (_, __) => message?.ToString());
 		}
 
-        /// <summary>
-        /// Send a "Warn" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsWarnEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Warn" is usually always available.
-        /// </remarks>
-        public static void WarnFormat(this ILogger log, string format, object arg0)
-        {
+		/// <summary>
+		/// Send a "Warn" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsWarnEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Warn" is usually always available.
+		/// </remarks>
+		public static void WarnFormat(this ILogger log, string format, object arg0)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, arg0);
 			log.Log<object>(LogLevel.Warning, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Warn" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsWarnEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Warn" is usually always available.
-        /// </remarks>
-        public static void WarnFormat(this ILogger log, string format, object arg0, object arg1)
-        {
+		/// <summary>
+		/// Send a "Warn" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsWarnEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Warn" is usually always available.
+		/// </remarks>
+		public static void WarnFormat(this ILogger log, string format, object arg0, object arg1)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1);
 			log.Log<object>(LogLevel.Warning, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Warn" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsWarnEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Warn" is usually always available.
-        /// </remarks>
-        public static void WarnFormat(this ILogger log, string format, object arg0, object arg1, object arg2)
-        {
+		/// <summary>
+		/// Send a "Warn" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsWarnEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Warn" is usually always available.
+		/// </remarks>
+		public static void WarnFormat(this ILogger log, string format, object arg0, object arg1, object arg2)
+		{
 			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1, arg2);
 			log.Log<object>(LogLevel.Warning, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Warn" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsWarnEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Warn" is usually always available.
-        /// </remarks>
-        public static void WarnFormat(this ILogger log, string format, params object[] args)
-        {
-            var message = string.Format(CultureInfo.InvariantCulture, format, args);
+		/// <summary>
+		/// Send a "Warn" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsWarnEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Warn" is usually always available.
+		/// </remarks>
+		public static void WarnFormat(this ILogger log, string format, params object[] args)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, args);
 			log.Log<object>(LogLevel.Warning, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Warn" message to configured loggers using a deferred action to build the message,
-        /// if the Warn log level is enabled.
-        /// </summary>
-        public static void Warn(this ILogger log, Func<object> messageBuilder, Exception exception = null)
-        {
-            if (log.IsEnabled(LogLevel.Warning))
-            {
+		/// <summary>
+		/// Send a "Warn" message to configured loggers using a deferred action to build the message,
+		/// if the Warn log level is enabled.
+		/// </summary>
+		public static void Warn(this ILogger log, Func<object> messageBuilder, Exception exception = null)
+		{
+			if (log.IsEnabled(LogLevel.Warning))
+			{
 				log.Log<object>(LogLevel.Warning, 0, null, exception, (_, __) => messageBuilder()?.ToString());
 			}
-        }
+		}
 
-        /// <summary>
-        /// Send a "Warn" message to configured loggers.
-        /// </summary>
-        public static void Warn(this ILogger log, string message, Exception exception = null)
-        {
+		/// <summary>
+		/// Send a "Warn" message to configured loggers.
+		/// </summary>
+		public static void Warn(this ILogger log, string message, Exception exception = null)
+		{
 			log.Log<object>(LogLevel.Warning, 0, null, exception, (_, __) => message);
-        }
+		}
 
-        /// <summary>
-        /// Send a "Error" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsErrorEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Error" is usually always available.
-        /// </remarks>
-        public static void ErrorFormat(this ILogger log, object message)
-        {
+		/// <summary>
+		/// Send a "Error" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsErrorEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Error" is usually always available.
+		/// </remarks>
+		public static void ErrorFormat(this ILogger log, object message)
+		{
 			log.Log<object>(LogLevel.Error, 0, null, null, (_, __) => message?.ToString());
 		}
 
-        /// <summary>
-        /// Send a "Error" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsErrorEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Error" is usually always available.
-        /// </remarks>
-        public static void ErrorFormat(this ILogger log, string format, object arg0)
-        {
-            var message = string.Format(CultureInfo.InvariantCulture, format, arg0);
+		/// <summary>
+		/// Send a "Error" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsErrorEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Error" is usually always available.
+		/// </remarks>
+		public static void ErrorFormat(this ILogger log, string format, object arg0)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0);
 			log.Log<object>(LogLevel.Error, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Error" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsErrorEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Error" is usually always available.
-        /// </remarks>
-        public static void ErrorFormat(this ILogger log, string format, object arg0, object arg1)
-        {
-            var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1);
+		/// <summary>
+		/// Send a "Error" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsErrorEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Error" is usually always available.
+		/// </remarks>
+		public static void ErrorFormat(this ILogger log, string format, object arg0, object arg1)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1);
 			log.Log<object>(LogLevel.Error, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Error" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsErrorEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Error" is usually always available.
-        /// </remarks>
-        public static void ErrorFormat(this ILogger log, string format, object arg0, object arg1, object arg2)
-        {
-            var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1, arg2);
+		/// <summary>
+		/// Send a "Error" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsErrorEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Error" is usually always available.
+		/// </remarks>
+		public static void ErrorFormat(this ILogger log, string format, object arg0, object arg1, object arg2)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1, arg2);
 			log.Log<object>(LogLevel.Error, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Error" message to configured loggers.
-        /// </summary>
-        /// <remarks>
-        /// If the construction of the message is costly, you should check the .IsErrorEnabled
-        /// first to prevent useless processing constructing a logging message.
-        /// Note: "Error" is usually always available.
-        /// </remarks>
-        public static void ErrorFormat(this ILogger log, string format, params object[] args)
-        {
-            var message = string.Format(CultureInfo.InvariantCulture, format, args);
+		/// <summary>
+		/// Send a "Error" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsErrorEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Error" is usually always available.
+		/// </remarks>
+		public static void ErrorFormat(this ILogger log, string format, params object[] args)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, args);
 			log.Log<object>(LogLevel.Error, 0, null, null, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Error" message to configured loggers using a deferred action to build the message,
-        /// if the Error log level is enabled.
-        /// </summary>
-        public static void Error(this ILogger log, string message, Exception exception = null)
-        {
+		/// <summary>
+		/// Send a "Error" message to configured loggers using a deferred action to build the message,
+		/// if the Error log level is enabled.
+		/// </summary>
+		public static void Error(this ILogger log, string message, Exception exception = null)
+		{
 			log.Log<object>(LogLevel.Error, 0, null, exception, (_, __) => message);
 		}
 
-        /// <summary>
-        /// Send a "Error" message to configured loggers using a deferred action to build the message,
-        /// if the Error log level is enabled.
-        /// </summary>
-        public static void Error(this ILogger log, Func<object> messageBuilder, Exception exception = null)
-        {
-            if (log.IsEnabled(LogLevel.Error))
-            {
+		/// <summary>
+		/// Send a "Error" message to configured loggers using a deferred action to build the message,
+		/// if the Error log level is enabled.
+		/// </summary>
+		public static void Error(this ILogger log, Func<object> messageBuilder, Exception exception = null)
+		{
+			if (log.IsEnabled(LogLevel.Error))
+			{
 				log.Log<object>(LogLevel.Error, 0, null, exception, (_, __) => (messageBuilder()?.ToString()));
 			}
-        }
-    }
+		}
+
+		/// <summary>
+		/// Send a "Critical" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsCriticalEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Critical" is usually always available.
+		/// </remarks>
+		public static void CriticalFormat(this ILogger log, object message)
+		{
+			log.Log<object>(LogLevel.Critical, 0, null, null, (_, __) => message?.ToString());
+		}
+
+		/// <summary>
+		/// Send a "Critical" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsCriticalEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Critical" is usually always available.
+		/// </remarks>
+		public static void CriticalFormat(this ILogger log, string format, object arg0)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0);
+			log.Log<object>(LogLevel.Critical, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a "Critical" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsCriticalEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Critical" is usually always available.
+		/// </remarks>
+		public static void CriticalFormat(this ILogger log, string format, object arg0, object arg1)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1);
+			log.Log<object>(LogLevel.Critical, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a "Critical" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsCriticalEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Critical" is usually always available.
+		/// </remarks>
+		public static void CriticalFormat(this ILogger log, string format, object arg0, object arg1, object arg2)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1, arg2);
+			log.Log<object>(LogLevel.Critical, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a "Critical" message to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsCriticalEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// Note: "Critical" is usually always available.
+		/// </remarks>
+		public static void CriticalFormat(this ILogger log, string format, params object[] args)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, args);
+			log.Log<object>(LogLevel.Critical, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a "Critical" message to configured loggers using a deferred action to build the message,
+		/// if the Critical log level is enabled.
+		/// </summary>
+		public static void Critical(this ILogger log, string message, Exception exception = null)
+		{
+			log.Log<object>(LogLevel.Critical, 0, null, exception, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a "Critical" message to configured loggers using a deferred action to build the message,
+		/// if the Critical log level is enabled.
+		/// </summary>
+		public static void Critical(this ILogger log, Func<object> messageBuilder, Exception exception = null)
+		{
+			if (log.IsEnabled(LogLevel.Critical))
+			{
+				log.Log<object>(LogLevel.Critical, 0, null, exception, (_, __) => (messageBuilder()?.ToString()));
+			}
+		}
+	}
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Feature


## What is the current behavior?
Log extension points don't allow tracing or critical errors.


## What is the new behavior?
Added extensions for tracing and critical errors.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.Core/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno.Core/blob/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
None

Internal Issue (If applicable):
https://dev.azure.com/nventive/Internal/_workitems/edit/147927