### PR TITLE
Adds log extension with a log level and a message builder.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -3,6 +3,7 @@
 ## Next version
 
  * Direct compatibility with projects targeting uap 10.0.17763
+ * Adds a log extension point with a provided log level and message builder.
 
 ### Features
 

--- a/src/Uno.Core/Logging/LogExtensions.cs
+++ b/src/Uno.Core/Logging/LogExtensions.cs
@@ -23,6 +23,90 @@ namespace Uno.Logging
 	public static partial class LogExtensions
 	{
 		/// <summary>
+		/// Send a log message of the provided log level to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void LogFormat(this ILogger log, LogLevel level, object message)
+		{
+			log.Log<object>(level, 0, null, null, (_, __) => message?.ToString());
+		}
+
+		/// <summary>
+		/// Send a log message of the provided log level to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void LogFormat(this ILogger log, LogLevel level, string format, object arg0)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0);
+			log.Log<object>(level, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a log message of the provided log level to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void LogFormat(this ILogger log, LogLevel level, string format, object arg0, object arg1)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1);
+			log.Log<object>(level, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a log message of the provided log level to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void LogFormat(this ILogger log, LogLevel level, string format, object arg0, object arg1, object arg2)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, arg0, arg1, arg2);
+			log.Log<object>(level, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a log message of the provided log level to configured loggers.
+		/// </summary>
+		/// <remarks>
+		/// If the construction of the message is costly, you should check the .IsEnabled
+		/// first to prevent useless processing constructing a logging message.
+		/// </remarks>
+		public static void LogFormat(this ILogger log, LogLevel level, string format, params object[] args)
+		{
+			var message = string.Format(CultureInfo.InvariantCulture, format, args);
+			log.Log<object>(level, 0, null, null, (_, __) => message);
+		}
+
+		/// <summary>
+		/// Send a log message of the provided log level to configured loggers.
+		/// </summary>
+		public static void Log(this ILogger log, LogLevel level, string message, Exception exception = null)
+		{
+			log.Log<object>(level, 0, null, exception, (_, __) => message);
+		}
+		
+		/// <summary>
+		/// Send a log message of the provided log level to configured loggers using a deferred action to build the message,
+		/// if the log level is enabled.
+		/// </summary>
+		public static void Log(this ILogger log, LogLevel level, Func<object> messageBuilder, Exception exception = null)
+		{
+			if (log.IsEnabled(level))
+			{
+				log.Log<object>(level, 0, null, exception, (_, __) => messageBuilder()?.ToString());
+			}
+		}
+
+		/// <summary>
 		/// Send a "Trace" message to configured loggers.
 		/// </summary>
 		/// <remarks>


### PR DESCRIPTION
GitHub Issue (If applicable): #
https://dev.azure.com/nventive/Internal/_workitems/edit/149435

## PR Type
What kind of change does this PR introduce?
Feature

## What is the current behavior?
No extension with a provided log level.


## What is the new behavior?
An extension with a provided log level.


## PR Checklist

- [x] Tested code with current [supported SDKs](../README.md)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.Core/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno.Core/blob/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://dev.azure.com/nventive/Internal/_workitems/edit/149435