### PR TITLE
Add Uno.MonoAnalyzers to prevent using string APIs introduced in 15.9 and later

### DIFF
--- a/src/Uno.Core.Build/Uno.Core.Build.csproj
+++ b/src/Uno.Core.Build/Uno.Core.Build.csproj
@@ -66,6 +66,10 @@
 			<ExcludeAssets>runtime</ExcludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+		<PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<Target Name="Publish" />

--- a/src/Uno.Core.Tests/Uno.Core.Tests.csproj
+++ b/src/Uno.Core.Tests/Uno.Core.Tests.csproj
@@ -15,6 +15,10 @@
 		<PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
 		<PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
 		<PackageReference Include="System.ValueTuple" Version="4.4.0" />
+		<PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.Core/Uno.Core.csproj
+++ b/src/Uno.Core/Uno.Core.csproj
@@ -36,6 +36,10 @@
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
 		<PackageReference Include="System.Collections.Immutable" Version="1.3.1" />
+		<PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4">
+		  <PrivateAssets>all</PrivateAssets>
+		  <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">


### PR DESCRIPTION
Add Uno.MonoAnalyzers to prevent using string APIs introduced in 15.9 and later