### PR TITLE
updated azure-pipeline triggers for new release branch naming convention

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -6,14 +6,18 @@ trigger:
     include:
       - master
       - beta
+      - release/beta/*
       - stable
+      - release/stable/*
 
 pr: 
   branches:
     include:
       - master
       - beta
+      - release/beta/*
       - stable
+      - release/stable/*
 
 steps:
   - checkout: self


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Build or CI related changes

## What is the current behavior?
CI triggers only on specific branches, `master`, `beta` and `stable`. 

## What is the new behavior?
The following has been added to the triggers for the new release branch naming convention:
- `release/beta/*`
- `release/stable/*`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.Core/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno.Core/blob/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/156034