### PR TITLE
fixed gitversion

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -1,6 +1,6 @@
 #addin "Cake.FileHelpers"
 #addin "Cake.Powershell"
-#tool "nuget:?package=GitVersion.CommandLine&version=3.6.5" 
+#tool "nuget:?package=GitVersion.CommandLine&version=4.0.0" 
 
 using System;
 using System.Linq;

--- a/gitversion.yml
+++ b/gitversion.yml
@@ -4,18 +4,30 @@ next-version: 1.29.0
 continuous-delivery-fallback-tag: ""
 branches:
   master:
+    regex: master
     tag: dev
     increment: none
   beta:
-    tag: beta
+    regex: release/beta/
+    tag: 'beta'
     increment: none
-  (stable):
-    tag:
+    source-branches: ['master']
+  stable:
+    regex: release/stable/
+    tag: ''
     increment: none
-  dev/.*?/(.*?):
+    source-branches: ['master']
+  dev:
+    regex: dev/.*?/(.*?)
     tag: dev.{BranchName}
-  projects/(.*?):
+    source-branches: ['master']
+  projects:
     tag: proj-{BranchName}
-    increment: none
+    regex: projects/(.*?)
+    source-branches: ['master']
+  feature:
+    tag: feature.{BranchName}
+    regex: feature/(.*?)
+    source-branches: ['master']
 ignore:
   sha: []


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type
What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
`gitversion` calculates the version for `release/stable` branches as if they are "beta".

## What is the new behavior?
`gitversion` should now gives the correct version for each branch.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)

## Other information
```
  releases?[/-]:
    mode: ContinuousDeployment
    tag: beta
    increment: Patch
    prevent-increment-of-merged-branch-version: true
    track-merge-target: false
```
By default, the above is included in the base configuration of gitversion, and there is no way to alter it beside reuse the same `releases?[/-]`. This is bad for our use-case since `release/beta` and `release/stable` need to have different tag.
Attempting to declare a different filter to matches these separately would result in the following error in 3.6.5:
> System.Exception: Multiple branch configurations match the current branch branchName of 'release/stable/Batman'. Matching configurations: 'release/stable, releases?[/-]'

This is why we had to move to 4.0.0 and update the `gitversion.yml` to follow the new format.

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/157368