### PR TITLE
Fix GetBaseTypes() extension

### DIFF
--- a/src/Uno.Core.Tests/Reflection/TypeExtensionsFixture.cs
+++ b/src/Uno.Core.Tests/Reflection/TypeExtensionsFixture.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.Extensions;
+
+namespace Uno.Core.Tests.Reflection
+{
+	[TestClass]
+	public class TypeExtensionsFixture
+	{
+		[TestMethod]
+		public void TestGetBaseTypes()
+		{
+			var baseTypes = typeof(MoreDerivedType).GetBaseTypes().ToArray();
+			CollectionAssert.AreEqual(new[] { typeof(DerivedType), typeof(BaseType), typeof(object) }, baseTypes);
+		}
+
+		public class BaseType { }
+
+		public class DerivedType : BaseType { }
+
+		public class MoreDerivedType : DerivedType { }
+	}
+}

--- a/src/Uno.Core.Tests/Reflection/TypeExtensionsFixture.cs
+++ b/src/Uno.Core.Tests/Reflection/TypeExtensionsFixture.cs
@@ -1,4 +1,20 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Uno.Core/Reflection/TypeExtensions.cs
+++ b/src/Uno.Core/Reflection/TypeExtensions.cs
@@ -248,16 +248,18 @@ namespace Uno.Extensions
             return type.GetCustomAttributes(typeof(TAttribute), true).FirstOrDefault() as TAttribute;
         }
 
-
+		/// <summary>
+		/// Gets the inheritance hierarchy of supplied type.
+		/// </summary>
         public static IEnumerable<Type> GetBaseTypes(this Type type)
         {
             var previousType = type;
             while (true)
             {
 #if !WINDOWS_UWP
-                var baseType = type.BaseType;
+                var baseType = previousType.BaseType;
 #else
-				var baseType = type.GetTypeInfo().BaseType;
+				var baseType = previousType.GetTypeInfo().BaseType;
 #endif
                 if (baseType == null || baseType.FullName == previousType.FullName)
                 {


### PR DESCRIPTION
Was only ever returning the first base type.

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.Core/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno.Core/blob/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->