### PR TITLE
Append line terminator in IndentedStringBuilder.AppendLine (#55)

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -7,7 +7,7 @@
 ### Breaking changes
 * 
 ### Bug fixes
-* 
+* #55: AppendLine insert new line at the end
 
 ## Release 1.28.0
 

--- a/src/Uno.Core/Extensions/IndentedStringBuilder.cs
+++ b/src/Uno.Core/Extensions/IndentedStringBuilder.cs
@@ -86,7 +86,7 @@ namespace Uno.Extensions
 
 		public virtual void AppendLine(string text)
 		{
-			_stringBuilder.Append(text.Indent(CurrentLevel));
+			_stringBuilder.AppendLine(text.Indent(CurrentLevel));
 		}
 
 		public override string ToString()


### PR DESCRIPTION
Corresponding to the behavior of .net's StringBuilder, the method AppendLine
should append a line terminator at the end.

GitHub Issue (If applicable): #55 

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
AppendLine(String) does not insert a new line at the end.

## What is the new behavior?
AppendLine(String) does inserts a new line at the end.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.Core/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno.Core/blob/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

I believe this can be a breaking change, but I'm not sure how should we proceed regarding this matter. Also, I've not added a test for this method as I haven't found a unit test for this class. Should we work to add these tests in this pull request?