### PR TITLE
Attempts to resolve ILogger<T> directly from IServiceProvider first

### DIFF
--- a/src/Uno.Core.Tests/LoggerFixture.cs
+++ b/src/Uno.Core.Tests/LoggerFixture.cs
@@ -54,7 +54,36 @@ namespace Uno.Core.Tests
 
 
 		[TestMethod]
-		public void TestWithExternalLogger()
+		public void TestNonGenericLogWithExternalLogger()
+		{
+			//setup
+			var originalProvider = ServiceLocator.IsLocationProviderSet
+				? ServiceLocator.Current
+				: default;
+
+			var fakeLocator = new FakeServiceLocator();
+
+			ServiceLocator.SetLocatorProvider(() => fakeLocator);
+
+			Assert.AreEqual(fakeLocator, ServiceLocator.Current);
+
+			var message = "Test logging";
+
+			typeof(string).Log().Debug(message);
+
+			Assert.AreEqual(1, fakeLocator.Outputs.Count);
+
+			var actualDebug = fakeLocator.Outputs.Single();
+			Assert.AreEqual(message, actualDebug.Message);
+			Assert.AreEqual(LogLevel.Debug, actualDebug.LogLevel);
+
+			//ensure 'restore'
+			ServiceLocator.SetLocatorProvider(() => originalProvider);
+			Assert.AreEqual(originalProvider, ServiceLocator.Current);
+		}
+
+		[TestMethod]
+		public void TestGenericLogWithExternalLogger()
 		{
 			//setup
 			var originalProvider = ServiceLocator.IsLocationProviderSet
@@ -70,17 +99,12 @@ namespace Uno.Core.Tests
 			var message = "Test logging";
 
 			5.Log().Warn(message);
-			typeof(string).Log().Debug(message);
 
-			Assert.AreEqual(2, fakeLocator.Outputs.Count);
+			Assert.AreEqual(1, fakeLocator.Outputs.Count);
 
-			var actualWarning = fakeLocator.Outputs[0];
+			var actualWarning = fakeLocator.Outputs.Single();
 			Assert.AreEqual(message, actualWarning.Message);
 			Assert.AreEqual(LogLevel.Warning, actualWarning.LogLevel);
-
-			var actualDebug = fakeLocator.Outputs[1];
-			Assert.AreEqual(message, actualDebug.Message);
-			Assert.AreEqual(LogLevel.Debug, actualDebug.LogLevel);
 
 			//ensure 'restore'
 			ServiceLocator.SetLocatorProvider(() => originalProvider);

--- a/src/Uno.Core.Tests/LoggerFixture.cs
+++ b/src/Uno.Core.Tests/LoggerFixture.cs
@@ -16,13 +16,13 @@
 // ******************************************************************
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 using CommonServiceLocator;
+
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 using Uno.Extensions;
 using Uno.Logging;
 

--- a/src/Uno.Core/Logging/LogExtensionPoint.cs
+++ b/src/Uno.Core/Logging/LogExtensionPoint.cs
@@ -15,10 +15,11 @@
 //
 // ******************************************************************
 using System;
-using CommonServiceLocator;
-using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 using System.Linq;
+
+using CommonServiceLocator;
+
+using Microsoft.Extensions.Logging;
 
 namespace Uno.Extensions
 {
@@ -45,7 +46,7 @@ namespace Uno.Extensions
 		/// <param name="forType"></param>
 		/// <returns></returns>
 		public static ILogger Log(this Type forType)
-			=> 
+			=>
 			TryGetLoggerFromServiceProvider(forType)
 			?? AmbientLoggerFactory.CreateLogger(forType);
 
@@ -102,8 +103,8 @@ namespace Uno.Extensions
 				{
 					var service = ServiceLocator.Current.GetService(typeof(ILogger<>).MakeGenericType(categoryTypeName));
 
-					if (service is ILogger logger 
-						&& logger.GetType().GenericTypeArguments.SequenceEqual(new[] { categoryTypeName }) )
+					if (service is ILogger logger
+						&& logger.GetType().GenericTypeArguments.SequenceEqual(new[] { categoryTypeName }))
 					{
 						return logger;
 					}
@@ -115,6 +116,5 @@ namespace Uno.Extensions
 
 			return null;
 		}
-
 	}
 }


### PR DESCRIPTION
This PR sets the `LogExtensionPoint`, so that when an `ILogger<T>` is requested, it'll first try to retrieve it first directly from the service provider.
This way, we can keep the filtering, console/debug providers, min-log level and other logging setting to the upper app-level configuration setup using `ILogginBuilder` with [generic-host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-3.1) or another third party tool.

Related: https://github.com/unoplatform/Uno.Core/issues/53