### PR TITLE
feat: attempt to resolve ILogger<T> directly from IServiceProvider first

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+indent_style = tab

--- a/src/Uno.Core.Tests/LoggerFixture.cs
+++ b/src/Uno.Core.Tests/LoggerFixture.cs
@@ -75,9 +75,18 @@ namespace Uno.Core.Tests
 			Assert.AreEqual(message, actualDebug.Message);
 			Assert.AreEqual(LogLevel.Debug, actualDebug.LogLevel);
 
-			//ensure 'restore'
-			ServiceLocator.SetLocatorProvider(() => originalProvider);
-			Assert.AreEqual(originalProvider, ServiceLocator.Current);
+			//teardown
+			if (originalProvider == null)
+			{
+				ServiceLocator.SetLocatorProvider(null);
+				Assert.IsFalse(ServiceLocator.IsLocationProviderSet);
+			}
+			else
+			{
+				ServiceLocator.SetLocatorProvider(() => originalProvider);
+				Assert.IsTrue(ServiceLocator.IsLocationProviderSet);
+				Assert.AreEqual(originalProvider, ServiceLocator.Current);
+			}
 		}
 
 		[TestMethod]
@@ -104,9 +113,18 @@ namespace Uno.Core.Tests
 			Assert.AreEqual(message, actualWarning.Message);
 			Assert.AreEqual(LogLevel.Warning, actualWarning.LogLevel);
 
-			//ensure 'restore'
-			ServiceLocator.SetLocatorProvider(() => originalProvider);
-			Assert.AreEqual(originalProvider, ServiceLocator.Current);
+			//teardown
+			if (originalProvider == null)
+			{
+				ServiceLocator.SetLocatorProvider(null);
+				Assert.IsFalse(ServiceLocator.IsLocationProviderSet);
+			}
+			else
+			{
+				ServiceLocator.SetLocatorProvider(() => originalProvider);
+				Assert.IsTrue(ServiceLocator.IsLocationProviderSet);
+				Assert.AreEqual(originalProvider, ServiceLocator.Current);
+			}
 		}
 
 		private class FakeServiceLocator : IServiceLocator

--- a/src/Uno.Core.Tests/LoggerFixture.cs
+++ b/src/Uno.Core.Tests/LoggerFixture.cs
@@ -14,11 +14,12 @@
 // limitations under the License.
 //
 // ******************************************************************
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using CommonServiceLocator;
+using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Uno.Extensions;
 using Uno.Logging;
@@ -26,7 +27,7 @@ using Uno.Logging;
 namespace Uno.Core.Tests
 {
 	[TestClass]
-	public class MyTestClass
+	public class LoggerFixtures
 	{
 		[TestMethod]
 		public void TestInfo()
@@ -47,6 +48,107 @@ namespace Uno.Core.Tests
 		public void TestDebug()
 		{
 			this.Log().Debug("Test logging");
+		}
+
+
+		[TestMethod]
+		public void TestNonGenericLogWithExternalLogger()
+		{
+			//setup
+			var originalProvider = ServiceLocator.IsLocationProviderSet
+				? ServiceLocator.Current
+				: default;
+
+			var fakeLocator = new FakeServiceLocator();
+
+			ServiceLocator.SetLocatorProvider(() => fakeLocator);
+
+			Assert.AreEqual(fakeLocator, ServiceLocator.Current);
+
+			var message = "Test logging";
+
+			typeof(string).Log().Debug(message);
+
+			Assert.AreEqual(1, fakeLocator.Outputs.Count);
+
+			var actualDebug = fakeLocator.Outputs.Single();
+			Assert.AreEqual(message, actualDebug.Message);
+			Assert.AreEqual(LogLevel.Debug, actualDebug.LogLevel);
+
+			//ensure 'restore'
+			ServiceLocator.SetLocatorProvider(() => originalProvider);
+			Assert.AreEqual(originalProvider, ServiceLocator.Current);
+		}
+
+		[TestMethod]
+		public void TestGenericLogWithExternalLogger()
+		{
+			//setup
+			var originalProvider = ServiceLocator.IsLocationProviderSet
+				? ServiceLocator.Current
+				: default;
+
+			var fakeLocator = new FakeServiceLocator();
+
+			ServiceLocator.SetLocatorProvider(() => fakeLocator);
+
+			Assert.AreEqual(fakeLocator, ServiceLocator.Current);
+
+			var message = "Test logging";
+
+			5.Log().Warn(message);
+
+			Assert.AreEqual(1, fakeLocator.Outputs.Count);
+
+			var actualWarning = fakeLocator.Outputs.Single();
+			Assert.AreEqual(message, actualWarning.Message);
+			Assert.AreEqual(LogLevel.Warning, actualWarning.LogLevel);
+
+			//ensure 'restore'
+			ServiceLocator.SetLocatorProvider(() => originalProvider);
+			Assert.AreEqual(originalProvider, ServiceLocator.Current);
+		}
+
+		private class FakeServiceLocator : IServiceLocator
+		{
+			public IList<(LogLevel LogLevel, EventId EventId, string Message)> Outputs { get; } = new List<(LogLevel, EventId, string)>();
+
+			public IEnumerable<object> GetAllInstances(Type serviceType) => throw new NotImplementedException();
+			public IEnumerable<TService> GetAllInstances<TService>() => throw new NotImplementedException();
+			public object GetInstance(Type serviceType) => throw new NotImplementedException();
+			public object GetInstance(Type serviceType, string key) => throw new NotImplementedException();
+			public TService GetInstance<TService>() => throw new NotImplementedException();
+			public TService GetInstance<TService>(string key) => throw new NotImplementedException();
+			public object GetService(Type serviceType)
+			{
+				if (serviceType.IsInterface && typeof(ILogger).IsAssignableFrom(serviceType)
+					&& serviceType.GenericTypeArguments.Length == 1)
+				{
+					return Activator
+						.CreateInstance(typeof(FakeLogger<>)
+						.MakeGenericType(serviceType.GenericTypeArguments.Single()), args: this);
+				}
+				else
+				{
+					throw new NotImplementedException();
+				}
+			}
+
+			class FakeLogger<T> : ILogger<T>
+			{
+				readonly FakeServiceLocator locator;
+				public FakeLogger(FakeServiceLocator locator)
+				{
+					this.locator = locator;
+				}
+
+				public IDisposable BeginScope<TState>(TState state) => throw new NotImplementedException();
+				public bool IsEnabled(LogLevel logLevel) => throw new NotImplementedException();
+				public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+				{
+					locator.Outputs.Add((logLevel, eventId, formatter(state, exception)));
+				}
+			}
 		}
 	}
 }

--- a/src/Uno.Core.sln
+++ b/src/Uno.Core.sln
@@ -1,13 +1,18 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27009.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30011.22
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.Core.Tests", "Uno.Core.Tests\Uno.Core.Tests.csproj", "{B554D7E4-17FC-4909-BA06-80B5B2FB0BD1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Core.Tests", "Uno.Core.Tests\Uno.Core.Tests.csproj", "{B554D7E4-17FC-4909-BA06-80B5B2FB0BD1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Core", "Uno.Core\Uno.Core.csproj", "{ABB4F177-6966-4C24-A465-A5E941A70680}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.Core.Build", "Uno.Core.Build\Uno.Core.Build.csproj", "{E414AC61-1BED-458E-A78C-868514DDA1A2}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{84F31EF7-5A72-4F66-A7B5-364CA9F9E22F}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Uno.Core/Logging/LogExtensionPoint.cs
+++ b/src/Uno.Core/Logging/LogExtensionPoint.cs
@@ -14,26 +14,29 @@
 // limitations under the License.
 //
 // ******************************************************************
+
 using System;
+using System.Linq;
 using CommonServiceLocator;
 using Microsoft.Extensions.Logging;
-using System.Diagnostics;
 
 namespace Uno.Extensions
 {
-    public static class LogExtensionPoint
-    {
-        private static ILoggerFactory _loggerFactory;
+	public static class LogExtensionPoint
+	{
+		private static ILoggerFactory _loggerFactory;
 
-        private static class Container<T>
-        {
-            internal static readonly ILogger Logger = AmbientLoggerFactory.CreateLogger<T>();
-        }
+		private static class Container<T>
+		{
+			internal static readonly ILogger Logger =
+				TryGetLoggerFromServiceProvider(typeof(T))
+				?? AmbientLoggerFactory.CreateLogger<T>();
+		}
 
 		/// <summary>
 		/// Retreives the <see cref="ILoggerFactory"/> for this the Uno extension point.
 		/// </summary>
-		public static ILoggerFactory AmbientLoggerFactory 
+		public static ILoggerFactory AmbientLoggerFactory
 			=> Transactional.Update(ref _loggerFactory, l => l ?? GetFactory());
 
 		/// <summary>
@@ -41,8 +44,10 @@ namespace Uno.Extensions
 		/// </summary>
 		/// <param name="forType"></param>
 		/// <returns></returns>
-		public static ILogger Log(this Type forType) 
-			=> AmbientLoggerFactory.CreateLogger(forType);
+		public static ILogger Log(this Type forType)
+			=>
+			TryGetLoggerFromServiceProvider(forType)
+			?? AmbientLoggerFactory.CreateLogger(forType);
 
 		/// <summary>
 		/// Gets a logger instance for the current types
@@ -87,6 +92,28 @@ namespace Uno.Extensions
 			{
 				return new LoggerFactory();
 			}
+		}
+
+		private static ILogger TryGetLoggerFromServiceProvider(Type categoryTypeName)
+		{
+			if (ServiceLocator.IsLocationProviderSet)
+			{
+				try
+				{
+					var service = ServiceLocator.Current.GetService(typeof(ILogger<>).MakeGenericType(categoryTypeName));
+
+					if (service is ILogger logger
+						&& logger.GetType().GenericTypeArguments.SequenceEqual(new[] { categoryTypeName }))
+					{
+						return logger;
+					}
+				}
+				catch
+				{
+				}
+			}
+
+			return null;
 		}
 	}
 }


### PR DESCRIPTION
This PR sets the `LogExtensionPoint`, so that when an `ILogger<T>` is requested, it'll first try to retrieve it first directly from the service provider.
This way, we can keep the filtering, console/debug providers, min-log level and other logging setting to the upper app-level configuration setup using `ILogginBuilder` with [generic-host](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/generic-host?view=aspnetcore-3.1) or another third party tool.

Related: https://github.com/unoplatform/Uno.Core/issues/53