### PR TITLE
fix: Add more uap targets to avoid `System.Runtime.InteropServices.WindowsRuntime` mismatches in desktop packaging

### DIFF
--- a/src/Uno.Core/Uno.Core.csproj
+++ b/src/Uno.Core/Uno.Core.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>uap10.0;net46;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
+		<TargetFrameworks>uap10.0;uap10.0.17763;uap10.0.19041;net46;netstandard2.0;netstandard2.1;net5.0</TargetFrameworks>
 		<AssemblyName>Uno.Core</AssemblyName>
 		<RootNamespace>Uno.Core</RootNamespace>
 		<Product>$(AssemblyName) ($(TargetFramework))</Product>
@@ -32,10 +32,10 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Memory" Version="4.5.2" Condition="'$(TargetFramework)'=='uap10.0' or '$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='net46'"/>
+		<PackageReference Include="System.Memory" Version="4.5.2" Condition="$(TargetFramework.StartsWith('uap10.0')) or '$(TargetFramework)'=='netstandard2.0' or '$(TargetFramework)'=='net46'"/>
 	</ItemGroup>
 
-	<PropertyGroup Condition="'$(TargetFramework)' == 'uap10.0'">
+	<PropertyGroup Condition="$(TargetFramework.StartsWith('uap10.0'))">
 		<DefineConstants>$(DefineConstants);NETFX_CORE;WINDOWS_UWP;HAS_DICT_GETVALUEORDEFAULT</DefineConstants>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net46'">


### PR DESCRIPTION
GitHub Issue (If applicable): fixes https://github.com/unoplatform/uno/issues/6065

<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?

Packaging an UWP application with a min version not matching the uap10.0 generic target defined by msbuild extras causes issues with the assembly loader (such as this one https://stackoverflow.com/questions/48211211/uwp-application-could-not-load-file-or-assembly-system-runtime-windowsruntime).

This change adds more explicit targets to avoid mismatches.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno.Core/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno.Core/blob/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->