### PR TITLE
fix: Restore original namespace for SynchronizedDictionary.FindOrCreate

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<DisableImplicitNamespaceImports>True</DisableImplicitNamespaceImports> <!-- To remove when .NET 6 RC1 is released -->
+
 		<IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
 		<IsSampleProject>$(MSBuildProjectName.Contains('Sample'))</IsSampleProject>
 	</PropertyGroup>
@@ -26,13 +26,6 @@
 		<None Include="$(MSBuildThisFileDirectory)..\build\uno-logo.png" Pack="true" Visible="false" PackagePath="\"/>
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Uno.MonoAnalyzers" Version="1.0.0-dev.4" Condition="'$(TargetFramework)'=='netstandard2.0'">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
-	
 	<Choose>
 		<When Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false' and '$(IsSampleProject)' != 'true'">
 			<PropertyGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,6 +18,7 @@
 
 	<PropertyGroup>
 
+		<NoWarn>$(NoWarn);NU1701</NoWarn> <!-- Ignore Microsoft.CodeAnalysis.Common 1.2.0 nuget warnings -->
 		<IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
 		<IsSampleProject>$(MSBuildProjectName.Contains('Sample'))</IsSampleProject>
 	</PropertyGroup>

--- a/src/Uno.Core.Extensions.Compatibility/Collections/DictionaryExtensionsLegacy.cs
+++ b/src/Uno.Core.Extensions.Compatibility/Collections/DictionaryExtensionsLegacy.cs
@@ -8,7 +8,7 @@ using Uno.Collections;
 using Uno.Extensions;
 using Uno.Threading;
 
-namespace Uno.Core.Collections
+namespace Uno.Collections
 {
 	public static class DictionaryExtensionsLegacy
 	{

--- a/src/Uno.Core/ForwardedTypes.cs
+++ b/src/Uno.Core/ForwardedTypes.cs
@@ -132,7 +132,7 @@
 [assembly: TypeForwardedTo(typeof(Uno.Core.Funcs<>))]
 [assembly: TypeForwardedTo(typeof(Uno.Core.Funcs<,>))]
 [assembly: TypeForwardedTo(typeof(Uno.Core.Collections.CollectionsExtensionsLegacy))]
-[assembly: TypeForwardedTo(typeof(Uno.Core.Collections.DictionaryExtensionsLegacy))]
+[assembly: TypeForwardedTo(typeof(Uno.Collections.DictionaryExtensionsLegacy))]
 [assembly: TypeForwardedTo(typeof(Uno.Core.Collections.EnumerableExtensionsLegacy))]
 [assembly: TypeForwardedTo(typeof(Uno.Core.Collections.ListExtensionsLegacy))]
 [assembly: TypeForwardedTo(typeof(Uno.Collections.CollectionAdapter<,>))]


### PR DESCRIPTION
This may cause existing code which does not include `Uno.Core.Collections` to fallback to `IDictionary<,>`